### PR TITLE
Make pytest-runner optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 """The setup script."""
 
 from setuptools import setup, find_packages
+import sys
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
@@ -17,7 +18,8 @@ requirements = [
     'traittypes',
 ]
 
-setup_requirements = ['pytest-runner', ]
+needs_pytest = set(['pytest', 'test', 'ptr']).intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 test_requirements = [
     'pytest',
@@ -46,7 +48,7 @@ setup(
     keywords='bcc',
     name='bcc',
     packages=find_packages(include=['bcc']),
-    setup_requires=setup_requirements,
+    setup_requires=pytest_runner,
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/willsheffler/bcc',


### PR DESCRIPTION
Check for pytest-runner only if setup.py was
invoked with 'test' argument.
This setup is required to integrate bcc
into buildroot which allows to deploy
bcc on embedded systems.
More information can be found at :
http://patchwork.ozlabs.org/patch/1094504/.

Signed-off-by: Jugurtha BELKALEM <jugurtha.belkalem@smile.fr>